### PR TITLE
Add Ruuvi angle support

### DIFF
--- a/src/ble-dbus.c
+++ b/src/ble-dbus.c
@@ -20,6 +20,7 @@ const VeVariantUnitFmt veUnitG2Dec = { 2, "g" };
 const VeVariantUnitFmt veUnitdBm = { 0, "dBm" };
 const VeVariantUnitFmt veUnitcm = { 1, "cm" };
 const VeVariantUnitFmt veUnitm3 = { 3, "m3" };
+const VeVariantUnitFmt veUnitDegree = { 1, "°" };
 
 static struct VeSettingProperties empty_string = {
 	.type = VE_HEAP_STR,

--- a/src/ble-dbus.h
+++ b/src/ble-dbus.h
@@ -51,6 +51,7 @@ extern const VeVariantUnitFmt veUnitG2Dec;
 extern const VeVariantUnitFmt veUnitdBm;
 extern const VeVariantUnitFmt veUnitcm;
 extern const VeVariantUnitFmt veUnitm3;
+extern const VeVariantUnitFmt veUnitDegree;
 
 int ble_dbus_init(void);
 int ble_dbus_add_interface(const char *name, const char *addr);


### PR DESCRIPTION
Calculates x, y and z angle, based on the acceleration data and puts the calculated data on the dbus. 
Writing `1` to `/CalculateAngles` starts calculating the angles (`0` by default)
Writing `1` to '/CalibrateAngles` calibrates / zeroes the angles.